### PR TITLE
Deleted ReadMe.txt

### DIFF
--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -1,2 +1,0 @@
-Put this in 
-/lib/firmware


### PR DESCRIPTION
You may or may not be aware but the repo has README.md as well as ReadMe.txt.

The ReadMe.txt file is out-of-date as it mentions the locations of the files as `/lib/firmware` instead of `/lib/firmware/i915`.

I have deleted it since the information is repeated but up-to-date on README.md